### PR TITLE
get and update support

### DIFF
--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -5,6 +5,7 @@ const Promise = require('bluebird');
 const readFile = Promise.promisify(require('fs').readFile);
 const _ = require('lodash');
 const log = require('./logger');
+const kv = require('consul-kv-object');
 
 /*
  * Creates a workflow that will synchronize one or more JSON files with consul's key-value store.
@@ -110,6 +111,34 @@ module.exports = (client, files) => {
     });
   };
 
+
+  /*
+   * Retrieves the list of keys that currently exist in consul.
+   */
+  const getKeysUnder = (keypath, json) => {
+    log.debug('Getting all keys under ' + keypath);
+
+    if(json) {
+      // https://github.com/lekoder/consul-to-json
+      var allKVs = Promise.promisifyAll(kv(client.kv, {concurrency: 3 }));
+      allKVs.getAsync(keypath).then(function(abranch) {
+        log.info(JSON.stringify(abranch, null, 4));
+      });
+      return
+    }
+
+    return client.kv.keysAsync(keypath)
+      .catch((err) => {
+        if (err.message === 'not found') {
+          return [];
+        }
+        throw err;
+      })
+      .then((keys) => {
+        log.info('Keys: ', keys);
+      });
+  };
+
   /*
    * Executes the workflow
    */
@@ -121,6 +150,22 @@ module.exports = (client, files) => {
       .then(put)
       .then(del);
   };
+
+  /*
+   * Update certain keys 
+   */
+  workflow.update = () => {
+    return Promise.map(files, readPointers)
+      .then(_.flatten)
+      .then(reduce)
+      .then(getExistingKeys) //not necessary but to avoid put() throwing error
+      .then(put)
+  }
+
+  workflow.get = (keypath, json) => {
+    return getKeysUnder(keypath, json)
+  }
+
 
   return workflow;
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "commander": "^2.9.0",
     "consul": "^0.22.0",
     "json-ptr": "^0.3.1",
+    "consul-kv-object": "^1.1.0",
     "lodash": "^3.10.1"
   },
   "config": {


### PR DESCRIPTION
# Ticket
https://techweb.axway.com/jira/browse/APIRS-3214
# Description
* get: allow to output all or a part of consul KVs in json format. 
  * Use -g or --get to specify a keypath to start with. If no keypath is provided all KVs will be printed. A keypath is a string which includes slash "/" separated keys.
  * Use --json to get output in json format, otherwise only keys will be printed.
```
  node consul-kv-sync --host 54.168.32.62 --port 8500 -g global/mongodb --json
  node consul-kv-sync.js --host 54.168.32.62 --port 8500 -g --json
```
* update: allow to update a set of keys with a json file. 
  * Use -u or --update to turn on update mode. Other parameters are same as when the
command is used to “sync”.
```
  node consul-kv-sync --host 54.168.32.62 --port 8500 -u test.json
```